### PR TITLE
Updates all death texts for English

### DIFF
--- a/Translations/English (default)/Death_Causes.txt
+++ b/Translations/English (default)/Death_Causes.txt
@@ -8,7 +8,7 @@ Fatal blunt trauma; the body is badly mutilated and pulped.
 [ammotype] gunshot wounds across the body.
 Cervical fracture at the base of the skull.
 Massive amounts of tissue decay is present on the body.
-Multiple surgical incisions & stitches can be seen.
+No clear trauma, but all vital systems appears to have stopped working.
 Unknown cause of death.
 It's <b>[user]</b>'s body - they were [class]!\n\nCause of death: [cause]
 Massive lacerations and blood loss.

--- a/Translations/English (default)/Death_Causes.txt
+++ b/Translations/English (default)/Death_Causes.txt
@@ -12,6 +12,6 @@ Multiple surgical incisions & stitches can be seen.
 Unknown cause of death.
 It's <b>[user]</b>'s body - they were [class]!\n\nCause of death: [cause]
 Massive lacerations and blood loss.
-Powerful bite to the cranium.
+Large, deep bitemarks around the cranium is observed.
 Melted by a highly corrosive substance.
 Shrapnel and third-degree burns caused by an explosion.

--- a/Translations/English (default)/Death_Causes.txt
+++ b/Translations/English (default)/Death_Causes.txt
@@ -1,17 +1,17 @@
 Died from an explosion.
-The fall ended their life.
+Shattered legs and feet suggest fatal trauma caused by a fall.
 Used as a sacrifice to re-contain SCP-106.
 Lost in the Pocket Dimension.
 It's a remnant of SCP-106.
-High-voltage electric shock.
-Crushed by a heavy structure.
-There are many gunshot wounds on the body. Most likely, a [ammotype] ammo type was used.
-Snapped neck at the base of the skull.
+Severe electrical burns.
+Fatal blunt trauma; badly mutilated and pulped.
+Gunshot wounds from a [ammotype] weapon.
+Cervical fracture at the base of the skull.
 Did not survive the encounter with SCP-106.
 Cured of a plague.
 Unknown cause of death.
-It's <b>[user]</b>'s body, they were [class]!\n\nCause of death: [cause]
-Was torn to pieces by SCP-096.
+It's <b>[user]</b>'s body - they were [class]!\n\nCause of death: [cause]
+Massive lacerations and blood loss.
 Powerful bite to the cranium.
 Melted by highly corrosive substance.
-Post-explosion wounds.
+Shrapnel and third-degree burns caused by an explosion.

--- a/Translations/English (default)/Death_Causes.txt
+++ b/Translations/English (default)/Death_Causes.txt
@@ -12,6 +12,6 @@ Sudden cessation of life signs. No clear trauma.
 Unknown cause of death.
 It's <b>[user]</b>'s body - they were [class]!\n\nCause of death: [cause]
 Massive lacerations and excessive blood loss.
-Large, deep bitemarks around the cranium is observed.
+Large, deep bite marks around the cranium are observed.
 Melted by a highly corrosive substance.
 Shrapnel and third-degree burns caused by an explosion.

--- a/Translations/English (default)/Death_Causes.txt
+++ b/Translations/English (default)/Death_Causes.txt
@@ -5,7 +5,7 @@ Decayed in the Pocket Dimension.
 It's a remnant of SCP-106.
 Severe electrical burns.
 Fatal blunt trauma; the body is badly mutilated and pulped.
-[ammotype] gunshot wounds.
+[ammotype] bullet wounds.
 Cervical fracture at the base of the skull.
 Massive amounts of tissue decay are present on the body.
 Sudden cessation of life signs. No clear trauma.

--- a/Translations/English (default)/Death_Causes.txt
+++ b/Translations/English (default)/Death_Causes.txt
@@ -1,15 +1,15 @@
-Died from an explosion.
+Vaporized by the Alpha Warheads.
 Shattered legs and feet suggest fatal trauma caused by a fall.
 Used as a sacrifice to re-contain SCP-106.
 Lost in the Pocket Dimension.
 It's a remnant of SCP-106.
 Severe electrical burns.
-Fatal blunt trauma; badly mutilated and pulped.
-Gunshot wounds from a [ammotype] weapon.
+Fatal blunt trauma; the body is badly mutilated and pulped.
+[ammotype] gunshot wounds across the body.
 Cervical fracture at the base of the skull.
 Did not survive the encounter with SCP-106.
 Cured of a plague.
-Unknown cause of death.
+Unknown.
 It's <b>[user]</b>'s body - they were [class]!\n\nCause of death: [cause]
 Massive lacerations and blood loss.
 Powerful bite to the cranium.

--- a/Translations/English (default)/Death_Causes.txt
+++ b/Translations/English (default)/Death_Causes.txt
@@ -5,9 +5,9 @@ Decayed in the Pocket Dimension.
 It's a remnant of SCP-106.
 Severe electrical burns.
 Fatal blunt trauma; the body is badly mutilated and pulped.
-[ammotype] gunshot wounds across the body.
+[ammotype] gunshot wounds.
 Cervical fracture at the base of the skull.
-Massive amounts of tissue decay is present on the body.
+Massive amounts of tissue decay are present on the body.
 Sudden cessation of life signs. No clear trauma.
 Unknown cause of death.
 It's <b>[user]</b>'s body - they were [class]!\n\nCause of death: [cause]

--- a/Translations/English (default)/Death_Causes.txt
+++ b/Translations/English (default)/Death_Causes.txt
@@ -8,10 +8,10 @@ Fatal blunt trauma; the body is badly mutilated and pulped.
 [ammotype] gunshot wounds across the body.
 Cervical fracture at the base of the skull.
 Massive amounts of tissue decay is present on the body.
-No clear trauma, but all vital systems appears to have stopped working.
+Sudden cessation of life signs. No clear trauma.
 Unknown cause of death.
 It's <b>[user]</b>'s body - they were [class]!\n\nCause of death: [cause]
-Massive lacerations and blood loss.
+Massive lacerations and excessive blood loss.
 Large, deep bitemarks around the cranium is observed.
 Melted by a highly corrosive substance.
 Shrapnel and third-degree burns caused by an explosion.

--- a/Translations/English (default)/Death_Causes.txt
+++ b/Translations/English (default)/Death_Causes.txt
@@ -1,6 +1,6 @@
 Vaporized by the Alpha Warhead.
 Shattered legs and feet suggest fatal trauma caused by a fall.
-Signs of severe trauma to both femur bones suggests death by circulatory shock
+Signs of severe trauma to both femur bones suggests death by circulatory shock.
 Decayed in the Pocket Dimension.
 It's a remnant of SCP-106.
 Severe electrical burns.

--- a/Translations/English (default)/Death_Causes.txt
+++ b/Translations/English (default)/Death_Causes.txt
@@ -1,6 +1,6 @@
 Vaporized by the Alpha Warhead.
 Shattered legs and feet suggest fatal trauma caused by a fall.
-Signs of severe trauma to both femur bones sugggests death by circulatory shock
+Signs of severe trauma to both femur bones suggests death by circulatory shock
 Decayed in the Pocket Dimension.
 It's a remnant of SCP-106.
 Severe electrical burns.

--- a/Translations/English (default)/Death_Causes.txt
+++ b/Translations/English (default)/Death_Causes.txt
@@ -9,7 +9,7 @@ Fatal blunt trauma; the body is badly mutilated and pulped.
 Cervical fracture at the base of the skull.
 Did not survive the encounter with SCP-106.
 Cured of a plague.
-Unknown.
+Unknown cause of death.
 It's <b>[user]</b>'s body - they were [class]!\n\nCause of death: [cause]
 Massive lacerations and blood loss.
 Powerful bite to the cranium.

--- a/Translations/English (default)/Death_Causes.txt
+++ b/Translations/English (default)/Death_Causes.txt
@@ -1,17 +1,17 @@
 Vaporized by the Alpha Warhead.
 Shattered legs and feet suggest fatal trauma caused by a fall.
-Used as a sacrifice to re-contain SCP-106.
-Lost in the Pocket Dimension.
+Signs of severe trauma to both femur bones sugggests death by circulatory shock
+Decayed in the Pocket Dimension.
 It's a remnant of SCP-106.
 Severe electrical burns.
 Fatal blunt trauma; the body is badly mutilated and pulped.
 [ammotype] gunshot wounds across the body.
 Cervical fracture at the base of the skull.
-Did not survive the encounter with SCP-106.
-Cured of a plague.
+Massive amounts of tissue decay is present on the body.
+Multiple surgical incisions & stitches can be seen.
 Unknown cause of death.
 It's <b>[user]</b>'s body - they were [class]!\n\nCause of death: [cause]
 Massive lacerations and blood loss.
 Powerful bite to the cranium.
-Melted by highly corrosive substance.
+Melted by a highly corrosive substance.
 Shrapnel and third-degree burns caused by an explosion.

--- a/Translations/English (default)/Death_Causes.txt
+++ b/Translations/English (default)/Death_Causes.txt
@@ -1,4 +1,4 @@
-Vaporized by the Alpha Warheads.
+Vaporized by the Alpha Warhead.
 Shattered legs and feet suggest fatal trauma caused by a fall.
 Used as a sacrifice to re-contain SCP-106.
 Lost in the Pocket Dimension.


### PR DESCRIPTION
# SCP:SL Translation PR Template

## Language
English

## Type of change
- [ ] Added new language translation
- [x] Changed a currently existing translation

## Have you tested the changes you've made?
- [x] Yes (used the language pack in a few rounds; seemed to work alright!)
- [ ] No

# Checklist:
- [x] I have made sure to not commit changes to other stuff than my own or the default english one
- [ ] I have ran `EncodingNormalizer.exe` on my changed files before commiting 
   -  (Exception to this is when edits has __only__ been made in-browser) ⬅️ This!
- [x] I have made sure that I'm not submitting a duplicate translation 
- [x] I have not included any advertisements/pointers to non-game stuff other than author in the folder name

The current death messages are mostly all over the place tonally, and I wanted to unify them. I went through all of the (used!) death causes and gave them a clinical tone.

I haven't done anything like this, so let me know if I should be doing anything. I'm also not sure if the first one is actually used by the warheads or not, since I'm not a scrub who dies to the warhead, so correct me if I'm wrong.