### PR TITLE
Tweaks English translation for the F1 menu popup

### DIFF
--- a/Translations/English (default)/Facility.txt
+++ b/Translations/English (default)/Facility.txt
@@ -32,4 +32,4 @@ You escaped as a Class D and joined the Chaos Insurgency.
 YOU ARE
 Escape time: [escape_minutes] minutes and [escape_seconds] seconds
 Wait [time] until you can use [item] again.
-HOLD <color=white><b>F1</b></color> FOR MORE INFO
+Press <color=yellow><b>F1</b></color> for help.


### PR DESCRIPTION
The character info screen recently got some minor changes, including the fact that it's now press-to-toggle, instead of being held down. This updates the English translation accordingly, since the color of the text is now white by default, and because white with yellow highlighted text is more consistent with inventory errors and such.

# SCP:SL Translation PR Template

## Language
English

## Type of change
- [ ] Added new language translation
- [x] Changed a currently existing translation

## Have you tested the changes you've made?
- [x] Yes
- [ ] No

# Checklist:
- [x] I have made sure to not commit changes to other stuff than my own or the default english one
- [x] I have ran `EncodingNormalizer.exe` on my changed files before commiting 
   -  (Exception to this is when edits has __only__ been made in-browser)
- [x] I have made sure that I'm not submitting a duplicate translation 
- [x] I have not included any advertisements/pointers to non-game stuff other than author in the folder name
- [ ] I have made sure to label my translation folder by [Microsoft Language Tag Standards](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c)
   - Only in cases of new translations
