### PR TITLE
Implements death causes for new damage types

### DIFF
--- a/Translations/English (default)/Death_Causes.txt
+++ b/Translations/English (default)/Death_Causes.txt
@@ -18,3 +18,5 @@ Shrapnel and severe burns caused by an explosion.
 Pale skin and blood leaking from the mouth suggest internal bleeding caused by substance ingestion.
 Recontained.
 Blunt trauma and minor scratches are present on the body.
+Severe blood loss caused by deep wounds.
+Sickly yellow skin and a rancid smell suggests death by poison.


### PR DESCRIPTION
10.0 includes two new damage types; this PR implements translations for them.

# SCP:SL Translation PR Template

## Language
English

## Type of change
- [x] Added new language translation
- [ ] Changed a currently existing translation

## Have you tested the changes you've made?
- [x] Yes
- [ ] No

# Checklist:
- [x] I have made sure to not commit changes to other stuff than my own or the default english one
- [x] I have ran `EncodingNormalizer.exe` on my changed files before commiting 
   -  (Exception to this is when edits has __only__ been made in-browser)
- [x] I have made sure that I'm not submitting a duplicate translation 
- [x] I have not included any advertisements/pointers to non-game stuff other than author in the folder name
- [ ] I have made sure to label my translation folder by [Microsoft Language Tag Standards](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c)
   - Only in cases of **new** translations (Can be tested [Here](https://rextester.com/WDXPS97501))
